### PR TITLE
Ehrmagherd I fixed it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PHONY: tests
+.PHONY: tests
 
 html:
 	# Running sphinx-build to build html files in build folder.


### PR DESCRIPTION
Hahahahahaha there was a missing period and that caused the problem. The issue was that at the beginning of the Makefile I had 
```
PHONY: tests
```
and it needed to say 
```
.PHONY: tests
```
I'm gonna go take a nap.